### PR TITLE
Fixing WebVRManager to IOS

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -275,7 +275,11 @@ function WebVRManager ( renderer ) {
 
 	};
 
-	this.getCamera = function ( camera ) {
+    //
+    
+    this.cameraAutoUpdate = true
+    
+    this.updateCamera = function ( camera ) {
 
 		var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
 
@@ -348,7 +352,7 @@ function WebVRManager ( renderer ) {
 
 		// TODO (mrdoob) Double check this code
 
-		standingMatrixInverse.getInverse( standingMatrix );
+        standingMatrixInverse.copy( standingMatrix ).invert();
 
 		if ( referenceSpaceType === 'local-floor' ) {
 
@@ -361,7 +365,7 @@ function WebVRManager ( renderer ) {
 
 		if ( parent !== null ) {
 
-			matrixWorldInverse.getInverse( parent.matrixWorld );
+            matrixWorldInverse.copy( parent.matrixWorld ).invert();
 
 			cameraL.matrixWorldInverse.multiply( matrixWorldInverse );
 			cameraR.matrixWorldInverse.multiply( matrixWorldInverse );
@@ -370,9 +374,9 @@ function WebVRManager ( renderer ) {
 
 		// envMap and Mirror needs camera.matrixWorld
 
-		cameraL.matrixWorld.getInverse( cameraL.matrixWorldInverse );
-		cameraR.matrixWorld.getInverse( cameraR.matrixWorldInverse );
-
+        cameraL.matrixWorld.copy( cameraL.matrixWorldInverse ).invert();
+        cameraR.matrixWorld.copy( cameraR.matrixWorldInverse ).invert();
+        
 		cameraL.projectionMatrix.fromArray( frameData.leftProjectionMatrix );
 		cameraR.projectionMatrix.fromArray( frameData.rightProjectionMatrix );
 
@@ -395,7 +399,33 @@ function WebVRManager ( renderer ) {
 
 		return cameraVR;
 
+	}; 
+    
+    this.getCamera = function () {
+
+        return cameraVR;
+
+    };
+    
+    // Dummy to fix Firefox
+    
+    this.getFoveation = function () {
+        console.warn( 'THREE.WebVRManager: getFoveation() not used in WEBVR.' );
+    };
+    
+    this.setFoveation = function ( foveation ) {
+        console.warn( 'THREE.WebVRManager: setFoveation() not used in WEBVR.' );
+    };
+    
+    //
+    
+	this.getStandingMatrix = function () {
+
+		return standingMatrix;
+
 	};
+
+	this.isPresenting = false;
 
 	this.getStandingMatrix = function () {
 

--- a/src/renderers/webvr/WebVRUtils.js
+++ b/src/renderers/webvr/WebVRUtils.js
@@ -47,7 +47,7 @@ function setProjectionFromUnion( camera, cameraL, cameraR ) {
   camera.translateX( xOffset );
   camera.translateZ( zOffset );
   camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-  camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+  camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
 
   // Find the union of the frustum values of the cameras and scale
   // the values so that the near plane's position does not change in world space,


### PR DESCRIPTION
Making EventDispatcher methods enumerable to assign with WebVRManager.

Added this.cameraAutoUpdate = true, renamed this.getCamera to this.updateCamera, and put back this.getCamera with just the return cameraVR, as WebGLRenderer is calling this.updateCamera now.

Replaced deprecated getInverse (Both in WebVRManager and WebVRUtils)