### PR TITLE
Introduce dummy getEnvironmentBlendMode on WebVRManager to match WebXR

### DIFF
--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -425,6 +425,18 @@ function WebVRManager( renderer ) {
 
 	};
 
+	// Dummy getEnvironmentBlendMode to have the same API as WebXR
+
+	this.getEnvironmentBlendMode = function () {
+
+		if ( scope.isPresenting ) {
+
+			return 'opaque';
+
+		}
+
+	};
+
 	//
 
 	this.getStandingMatrix = function () {


### PR DESCRIPTION
Related issue:  https://github.com/aframevr/aframe/issues/5292

**Description**

Three.js r152 started querying the [`environmentBlendMode`](https://developer.mozilla.org/en-US/docs/Web/API/XRSession/environmentBlendMode) from the WebXR session. Since super-three maintains an alternative `WebVRManager` that forms a drop-in replacement for the `WebXRManager`, it should be updated to have a `getEnvironmentBlendMode` method as well.

This PR simply adds a dummy implementation that returns `opaque` in case a session is active, and undefined if not (mimicking the `WebXRManager` behaviour in case of a VR (i.e. non-AR) session)
