### PR TITLE
WebXRManager: Update user camera based on poseTarget instead of camera

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -585,7 +585,7 @@ class WebXRManager extends EventDispatcher {
 
 			}
 
-			updateUserCamera( camera, cameraXR, parent );
+			updateUserCamera( camera, cameraXR, object );
 
 		};
 


### PR DESCRIPTION
Related to: https://github.com/supermedium/three.js/pull/12
This small change got left out during the rebasing/squashing and as a result the behaviour is currently incorrect (view can fly off)