### PR TITLE
WebXR: check for null render target (#15)

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2216,7 +2216,7 @@ class WebGLRenderer {
 
 			renderTargetProperties.__autoAllocateDepthBuffer = depthTexture === undefined;
 
-			if ( ! renderTargetProperties.__autoAllocateDepthBuffer && ! _currentRenderTarget.isWebGLMultiviewRenderTarget ) {
+			if ( ! renderTargetProperties.__autoAllocateDepthBuffer && ( ! _currentRenderTarget || ! _currentRenderTarget.isWebGLMultiviewRenderTarget ) ) {
 
 				// The multisample_render_to_texture extension doesn't work properly if there
 				// are midframe flushes and an external depth buffer. Disable use of the extension.


### PR DESCRIPTION
Related issue: #15 

**Description**

Aframes does not render WebXR on Magic Leap browser. Magic Leap browser use WebXR layers but does not use OCULUS_multiview extension. As a result there is null check crash, when rendering an Aframes written WebXR content. Proposing a simple fix to resolve this issue.

*This contribution is funded by Magic Leap*