### PR TITLE
Enable post-processing in VR

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2338,7 +2338,7 @@ class WebGLRenderer {
 			// Render to base layer instead of canvas in WebXR
 			if ( renderTarget === null && this.xr.isPresenting ) {
 
-				renderTarget = this.xr._getRenderTarget();
+				renderTarget = this.xr.getRenderTarget();
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2335,8 +2335,6 @@ class WebGLRenderer {
 		const _scratchFrameBuffer = _gl.createFramebuffer();
 		this.setRenderTarget = function ( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
 
-
-
 			// Render to base layer instead of canvas in WebXR
 			if ( renderTarget === null && this.xr.isPresenting ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2335,6 +2335,15 @@ class WebGLRenderer {
 		const _scratchFrameBuffer = _gl.createFramebuffer();
 		this.setRenderTarget = function ( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
 
+
+
+			// Render to base layer instead of canvas in WebXR
+			if ( renderTarget === null && this.xr.isPresenting ) {
+
+				renderTarget = this.xr._getRenderTarget();
+
+			}
+
 			_currentRenderTarget = renderTarget;
 			_currentActiveCubeFace = activeCubeFace;
 			_currentActiveMipmapLevel = activeMipmapLevel;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -187,10 +187,6 @@ class WebXRManager extends EventDispatcher {
 			session = null;
 			newRenderTarget = null;
 
-
-			renderer.setPixelRatio( currentPixelRatio );
-			renderer.setSize( currentSize.width, currentSize.height, false );
-
 			//
 
 			animation.stop();
@@ -252,7 +248,7 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
-		this._getRenderTarget = function () {
+		this.getRenderTarget = function () {
 
 			return newRenderTarget;
 
@@ -311,8 +307,6 @@ class WebXRManager extends EventDispatcher {
 					glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
 
 					session.updateRenderState( { baseLayer: glBaseLayer } );
-
-
 
 					renderer.setPixelRatio( 1 );
 					renderer.setSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight, false );
@@ -400,10 +394,6 @@ class WebXRManager extends EventDispatcher {
 
 				customReferenceSpace = null;
 				referenceSpace = await session.requestReferenceSpace( referenceSpaceType );
-
-				currentPixelRatio = renderer.getPixelRatio();
-				renderer.getSize( currentSize );
-
 
 				animation.setContext( session );
 				animation.start();

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -187,6 +187,10 @@ class WebXRManager extends EventDispatcher {
 			session = null;
 			newRenderTarget = null;
 
+
+			renderer.setPixelRatio( currentPixelRatio );
+			renderer.setSize( currentSize.width, currentSize.height, false );
+
 			//
 
 			animation.stop();
@@ -248,6 +252,12 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
+		this._getRenderTarget = function () {
+
+			return newRenderTarget;
+
+		};
+
 		this.getFrame = function () {
 
 			return xrFrame;
@@ -301,6 +311,8 @@ class WebXRManager extends EventDispatcher {
 					glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
 
 					session.updateRenderState( { baseLayer: glBaseLayer } );
+
+
 
 					renderer.setPixelRatio( 1 );
 					renderer.setSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight, false );
@@ -388,6 +400,10 @@ class WebXRManager extends EventDispatcher {
 
 				customReferenceSpace = null;
 				referenceSpace = await session.requestReferenceSpace( referenceSpaceType );
+
+				currentPixelRatio = renderer.getPixelRatio();
+				renderer.getSize( currentSize );
+
 
 				animation.setContext( session );
 				animation.start();


### PR DESCRIPTION
This PR makes three.js (and therefore A-Frame while recompiled) compatible with Post Processing effects in VR. Without this Post Processing effects work in desktop mode but not in VR.
Refer to https://github.com/aframevr/aframe/pull/3645#issuecomment-2590561040 for previous discussions about this topic.

this modded three.js and relative A-Frame are already be tested in several examples by myself with very good results i.e. with bloom effect. 

Thanks to Cody Jason Bennet for the original mods: https://github.com/mrdoob/three.js/pull/26160