### PR TITLE
Improve compatibility of Post-Processing with VR

### DIFF
--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -9,6 +9,8 @@ import { CopyShader } from '../shaders/CopyShader.js';
 import { ShaderPass } from './ShaderPass.js';
 import { ClearMaskPass, MaskPass } from './MaskPass.js';
 
+const size = /* @__PURE__ */ new Vector2();
+
 class EffectComposer {
 
 	constructor( renderer, renderTarget ) {
@@ -19,7 +21,7 @@ class EffectComposer {
 
 		if ( renderTarget === undefined ) {
 
-			const size = renderer.getSize( new Vector2() );
+			renderer.getSize( size );
 			this._width = size.width;
 			this._height = size.height;
 
@@ -48,6 +50,22 @@ class EffectComposer {
 		this.copyPass.material.blending = NoBlending;
 
 		this.clock = new Clock();
+		
+		this.onSessionStateChange = this.onSessionStateChange.bind( this );
+		this.renderer.xr.addEventListener( 'sessionstart', this.onSessionStateChange );
+		this.renderer.xr.addEventListener( 'sessionend', this.onSessionStateChange );
+
+	}
+
+	onSessionStateChange() {
+
+		this.renderer.getSize( size );
+		this._width = size.width;
+		this._height = size.height;
+
+		this._pixelRatio = this.renderer.xr.isPresenting ? 1 : this.renderer.getPixelRatio();
+
+		this.setSize( this._width, this._height );
 
 	}
 
@@ -169,7 +187,7 @@ class EffectComposer {
 
 		if ( renderTarget === undefined ) {
 
-			const size = this.renderer.getSize( new Vector2() );
+			this.renderer.getSize( size );
 			this._pixelRatio = this.renderer.getPixelRatio();
 			this._width = size.width;
 			this._height = size.height;
@@ -222,6 +240,9 @@ class EffectComposer {
 		this.renderTarget2.dispose();
 
 		this.copyPass.dispose();
+
+		this.renderer.xr.removeEventListener( 'sessionstart', this.onSessionStateChange );
+		this.renderer.xr.removeEventListener( 'sessionend', this.onSessionStateChange );
 
 	}
 

--- a/examples/jsm/postprocessing/Pass.js
+++ b/examples/jsm/postprocessing/Pass.js
@@ -74,8 +74,13 @@ class FullScreenQuad {
 
 	render( renderer ) {
 
-		renderer.render( this._mesh, _camera );
+		// Disable XR projection for fullscreen effects
+		// https://github.com/mrdoob/three.js/pull/18846
+		const xrEnabled = renderer.xr.enabled;
 
+		renderer.xr.enabled = false;
+		renderer.render( this._mesh, _camera );
+		renderer.xr.enabled = xrEnabled;
 	}
 
 	get material() {


### PR DESCRIPTION
**Description**

the PR https://github.com/supermedium/three.js/pull/20 has made superthree post-processing compatible with VR. Another PR has been opened in A-Frame (https://github.com/aframevr/aframe/pull/5648) to create a minimal example to show bloom working in A-Frame in VR. A lot of hacks have been implemented in the JS of the example in order to make things work as intended, crucial part of them could be incorporated directly in super-three to lower the level of difficulty in user-land.


