### PR TITLE
Fix multiview for WebXRManager, some changes were lost in a previous rebase

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -524,7 +524,7 @@ class WebGLRenderer {
 
 		// xr
 
-		const xr = new WebXRManager( _this, _gl );
+		const xr = new WebXRManager( _this, _gl, extensions, multiviewStereo );
 
 		/**
 		 * A reference to the XR manager.

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -852,6 +852,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );
 
 		}
+	}
 
 	function setDeferTextureUploads( deferFlag ) {
 


### PR DESCRIPTION
But I still have a black screen when testing the https://aframe.io/aframe/examples/performance/multiview-extension/?multiview=on example but no errors so there is surely another change needed to make it work again, but no idea what.

@dmarcos there is no "Bump build" commit on the [super-r177](https://github.com/supermedium/three.js/commits/super-r177) branch, you probably did it but not pushed.
I see you fixed a } in super-r177 branch but not in dev, so I included it in this PR.