### PR TITLE
Fix multiview for WebXRManager, restoring and updating lost changes

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -524,7 +524,7 @@ class WebGLRenderer {
 
 		// xr
 
-		const xr = new WebXRManager( _this, _gl );
+		const xr = new WebXRManager( _this, _gl, extensions, multiviewStereo );
 
 		/**
 		 * A reference to the XR manager.
@@ -1687,6 +1687,8 @@ class WebGLRenderer {
 
 			if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
 
+			textures.runDeferredUploads();
+
 			// _gl.finish();
 
 			bindingStates.resetDefaultState();
@@ -2711,7 +2713,7 @@ class WebGLRenderer {
 			const renderTargetProperties = properties.get( renderTarget );
 
 			renderTargetProperties.__autoAllocateDepthBuffer = renderTarget.resolveDepthBuffer === false;
-			if ( ! renderTargetProperties.__autoAllocateDepthBuffer === false && ( ! _currentRenderTarget || ! _currentRenderTarget.isWebGLMultiviewRenderTarget ) ) {
+			if ( ! renderTargetProperties.__autoAllocateDepthBuffer ) {
 
 				// The multisample_render_to_texture extension doesn't work properly if there
 				// are midframe flushes and an external depth buffer. Disable use of the extension.

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -567,7 +567,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 		if ( parameters.alphaToCoverage )
 			_programLayers.enable( 21 );
 		if ( parameters.numMultiviewViews )
-			_programLayers.enable( 21 );
+			_programLayers.enable( 22 );
 
 		array.push( _programLayers.mask );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -853,6 +853,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
+	}
+
 	function setDeferTextureUploads( deferFlag ) {
 
 		_deferTextureUploads = deferFlag;


### PR DESCRIPTION
Based on #24. Turns out there were a couple more issues that needed to be resolved to get multiview working again.

- The `textures.runDeferredUploads()` call got lost
- The logic in `setRenderTargetTextures` changed in Three.js upstream, making the multiview specific changes no longer needed
- The cache key in `WebGLPrograms` used the same index for `numMultiviewViews` as `alphaToCoverage`. Most likely one got added upstream and the `numMultiviewViews` wasn't incremented.